### PR TITLE
test: calculateMiniplanetTiles と tileToMiniplanetId の一貫性 invariant を追加

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -103,4 +103,23 @@ describe('calculateMiniplanetTiles', () => {
       expect(mergedCount).toBe(originalCount);
     }
   });
+
+  it('every returned tile maps back to its miniplanet id via tileToMiniplanetId', () => {
+    const perMiniplanet = calculateMiniplanetTiles();
+    for (const [index, tiles] of perMiniplanet.entries()) {
+      const expectedId = index.toString().padStart(2, '0');
+      for (const tile of tiles) {
+        const zDiff = BASE_ZOOM - tile[2];
+        const size = 1 << zDiff;
+        const xStart = tile[0] << zDiff;
+        const yStart = tile[1] << zDiff;
+        for (let dx = 0; dx < size; dx++) {
+          for (let dy = 0; dy < size; dy++) {
+            const child: Tile = [xStart + dx, yStart + dy, BASE_ZOOM];
+            expect(tileToMiniplanetId(child)).toBe(expectedId);
+          }
+        }
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- `calculateMiniplanetTiles()` と `tileToMiniplanetId()` の一貫性を保証する invariant テストを 1 本追加
- 各 miniplanet の全マージタイルを BASE_ZOOM の子タイルに展開し、`tileToMiniplanetId()` で期待 id が返ることを検証
- マージタイルは zoom ≦ BASE_ZOOM を取りうるため、そのまま `tileToMiniplanetId` に渡すと undefined を返すケースがある。BASE_ZOOM へ展開してから検査している

## Why

既存テストは各関数を個別に検証していたが、3 つの公開関数（`tileToMiniplanetId`, `generateGeoJSON`, `calculateMiniplanetTiles`）を横断する最重要の不変条件「tile 分割結果と id 逆引きが一致する」が検証されていなかった。どちらか片方の実装が壊れても気づけない状態。

## Test plan

- [x] `npm test` がローカルで全件 pass（8/8、新規 1 件含む）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * `calculateMiniplanetTiles()`関数の包括的なテストケースを追加しました。マージされたタイルの正確性とID マッピング との整合性を検証し、コード品質を向上させています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->